### PR TITLE
v3

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,7 +10,6 @@
         "react"
     ],
     "plugins": [
-        "glamorous-displayname",
         "transform-object-rest-spread"
     ],
     "env": {

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "printWidth": 80,
+  "tabWidth": 4,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "jsxBracketSameLine": false,
+  "fluid": false
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,10 @@ Before opening an issue, please search the [issue tracker](https://github.com/ED
 
 Visit the [Issue tracker](https://github.com/EDITD/react-responsive-picture/issues) to find a list of open issues that need attention.
 
-Fork, then clone the repo:
+The quickest and easiest way of starting developing this library is by using the specific Codesandbox available at: https://codesandbox.io/s/github/EDITD/react-responsive-picture/
+
+
+If you want to use the more traditional way, start by forking and then cloning the repo:
 ```
 git clone https://github.com/your-username/react-responsive-picture.git
 ```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 A future-proof responsive image component that supports latest `<picture>` specification. Uses [picturefill](https://github.com/scottjehl/picturefill) for backward compatibility from IE9+.
 
+[![npm version][version-badge]][npm]
+[![npm downloads][downloads-badge]][npm]
+[![gzip size][size-badge]][size]
+[![MIT License][license-badge]][license]
+[![PRs Welcome][prs-badge]][prs]
+
 ---
 
 ## Installation
@@ -212,3 +218,13 @@ Please follow our [contributing guidelines](https://github.com/EDITD/react-respo
 
 [MIT](https://github.com/EDITD/react-responsive-picture/blob/master/LICENSE)
 
+[npm]: https://www.npmjs.com/package/react-responsive-picture
+[license]: https://github.com/EDITD/react-responsive-picture/blob/master/LICENSE
+[prs]: http://makeapullrequest.com
+[size]: https://unpkg.com/react-responsive-picture/dist/react-responsive-picture.min.js
+[version-badge]: https://img.shields.io/npm/v/react-responsive-picture.svg?style=flat-square
+[downloads-badge]: https://img.shields.io/npm/dm/react-responsive-picture.svg?style=flat-square
+[license-badge]: https://img.shields.io/npm/l/react-responsive-picture.svg?style=flat-square
+[size-badge]: http://img.badgesize.io/https://unpkg.com/react-responsive-picture/dist/react-responsive-picture.min.js?compression=gzip&style=flat-square
+[modules-badge]: https://img.shields.io/badge/module%20formats-umd%2C%20cjs%2C%20esm-green.svg?style=flat-square
+[prs-badge]: https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square

--- a/README.md
+++ b/README.md
@@ -8,13 +8,9 @@ A future-proof responsive image component that supports latest `<picture>` speci
 
 `npm install react-responsive-picture` or `yarn add react-responsive-picture`
 
-#### Dependencies
-
-`react-responsive-picture` requires `glamor` installed as peer dependency since version `2.0.0` so you need to add it (in case you're not using it in your project) by running:
-
-`npm install glamor` or `yarn add glamor`
-
 ## How to use
+
+Playground: https://codesandbox.io/s/github/EDITD/react-responsive-picture/
 
 ### Code
 
@@ -53,9 +49,6 @@ class App extends Component {
 | sizes | string |  | Sizes attribute to be used with `src` for determing best image for user's viewport. |
 | alt | string |  | Alternative text for image |
 | className | string | | Any additional CSS classes you might want to use to style the image |
-| css | object \|\| array \|\| string |  | Any additional styles you might want to send to the wrapper. Uses [glamorous](https://github.com/paypal/glamorous) to process it so you can send an object, an array or even `glamor` generated string classes. |
-
-**Note:** Before version `2.0.0` the `style` prop was parsed by `glamor` so it wasn't having the same behaviour as applying the `style` prop to any other React component. For that reason, the recommended prop to override the styles is now `css`, which will be parsed by `glamorous` and applied to the component. The `style` prop will be treated as inline styles so it still works, but you can't have the nice features from `glamor` like hover states or media queries so be very careful about using it.
 
 ## Examples
 
@@ -137,7 +130,22 @@ The `sources` prop is where you can determine the behaviour of the `<Picture>` c
 
 For each source you can send an object containing `srcSet`, `media` and `type` although the last two are optional.
 
-## Utilities
+### Styling 
+
+You can use your favourite styling library and style the `Picture` component using the `className` prop.
+
+```jsx
+import { css } from "emotion";
+
+<Picture 
+    className={css`
+      opacity: 0.7;
+    `}
+    src="path-to-image@2x.png 2x, path-to-image.png 1x" 
+/>
+```
+
+## Fullsize images
 
 There's also a `<FullsizePicture>` component that you can use to display full-size images using the same benefits of `<Picture>` for art direction.
 
@@ -157,14 +165,44 @@ There's also a `<FullsizePicture>` component that you can use to display full-si
 </div>
 ```
 
-It will automatically fill the entire parent element maintaining the original image ratio. Please note that the parent element needs to have a defined height as you would expect for any background image as well.
+It will automatically fill the width or the height of the parent element maintaining the original image ratio. Please note that the parent element needs to have a defined height as you would expect for any background image as well.
 
-`FullsizePicture` accepts the same props as `Picture` plus a few more for styling.
+### Props
+
+`FullsizePicture` accepts the same props as `Picture` plus a few more for styling and positioning.
 
 | Prop | Type | Default | Definition |
 | --- | --- | --- | --- |
-| pictureClassName | string | | Any additional CSS classes you might want to use to style the inner `Picture` component |
-| pictureCSS | object \|\| array \|\| string |  | Any additional styles you might want to send to the inner `Picture` component |
+| sources | array |  | The array of source objects. Check Sources section for more information. |
+| src | string | (transparent pixel) | Source for standalone/fallback image. To prevent issues in some browsers, by default `src` is set to a 1x1 transparent pixel data image. |
+| sizes | string |  | Sizes attribute to be used with `src` for determing best image for user's viewport. |
+| alt | string |  | Alternative text for image |
+| className | string | | Any additional CSS classes you might want to use to style the image |
+| wrapperClassName | string | | Any additional CSS classes you might want to use to style the wrapper of the `Picture` component |
+| cover | "width" \| "height" | "width" | Decides the fullsize behaviour of the `Picture` component. By default it covers the width of the parent, but can be changed to cover the height instead. |
+| center | boolean | false | Helper prop to horizontally and vertically center the image. |
+
+### Use as background image
+
+If you want to use `FullsizePicture` as a background image for other components, you can pass them as children too.
+
+```jsx
+<section style={{ height: 200 }}>
+    <FullsizePicture
+        sources = {[
+            {
+                srcSet: "path-to-mobile-image.jpg, path-to-mobile-image@2x.jpg 2x",
+                media: "(max-width: 420px)",
+            },
+            {
+                srcSet: "path-to-desktop-image.jpg 1x, path-to-desktop-image@2x.jpg 2x",
+            },
+        ]}
+    >
+      <Heading1>This is the section title</Heading1>
+    </FullsizePicture>
+</section>
+```
 
 ## Contributing
 

--- a/examples/App.js
+++ b/examples/App.js
@@ -1,64 +1,70 @@
 import React from "react";
-import { FullsizePicture } from "../src";
+import { Picture, FullsizePicture } from "../src";
 import cxs from "cxs/component";
+import { default as cxsStyles } from "cxs";
 
-const StyledPicture = cxs(FullsizePicture)({
-    opacity: 0.8,
+const styles = cxsStyles({
+    opacity: 0.5,
 });
 
 const Heading1 = cxs("h1")({
     position: "relative",
     textAlign: "center",
     color: "white",
+    marginTop: 50,
 });
 
 const App = () => (
     <div>
-        <div style={{ height: 200 }}>
-            <StyledPicture
+        <h2>Picture with art direction</h2>
+        <div>
+            <Picture
                 sources={[
                     {
                         srcSet:
-                            "https://edited.com/static/img/homepage/edited-hero-table-wide.jpg",
-                        media: "(max-width: 420px)",
+                            "https://placeholdit.co//i/400x400?text=Mobile%20image&bg=450000",
+                        media: "(max-width: 380px)",
                     },
                     {
                         srcSet:
-                            "https://edited.com/static/img/homepage/edited-hero-table-wide.jpg",
+                            "https://placeholdit.co//i/500x250?text=Normal%20image&bg=450000 1x, https://placeholdit.co//i/1000x500?text=Retina%20image&bg=450000 2x",
+                    },
+                ]}
+            />
+        </div>
+        <h2>Full-height Picture with art direction</h2>
+        <div style={{ height: 400 }}>
+            <FullsizePicture
+                sources={[
+                    {
+                        srcSet:
+                            "https://placeholdit.co//i/400x400?text=Mobile%20image",
+                        media: "(max-width: 380px)",
+                    },
+                    {
+                        srcSet:
+                            "https://placeholdit.co//i/500x250?text=Normal%20image 1x, https://placeholdit.co//i/1000x500?text=Retina%20image 2x",
                     },
                 ]}
                 cover="height"
                 center={true}
             />
         </div>
-        <div style={{ height: 200 }}>
+        <h2>Full-width Picture with content</h2>
+        <div style={{ height: 400 }}>
             <FullsizePicture
-                sources={[
-                    {
-                        srcSet:
-                            "https://edited.com/static/img/homepage/edited-hero-table-wide.jpg",
-                        media: "(max-width: 420px)",
-                    },
-                    {
-                        srcSet:
-                            "https://edited.com/static/img/homepage/edited-hero-table-wide.jpg",
-                    },
-                ]}
-                cover="height"
+                src="https://images.unsplash.com/photo-1470619549108-b85c56fe5be8?dpr=2&auto=format&w=1024&h=1024"
                 center={true}
-            />
-        </div>
-        <div style={{ height: 200 }}>
-            <FullsizePicture
-                sources={[
-                    {
-                        srcSet:
-                            "https://images.unsplash.com/photo-1470619549108-b85c56fe5be8?dpr=2&auto=format&w=1024&h=1024",
-                    },
-                ]}
             >
                 <Heading1 className="App-title">This is a heading</Heading1>
             </FullsizePicture>
+        </div>
+        <h2>Styled Picture</h2>
+        <div>
+            <Picture
+                className={styles}
+                src="https://placeholdit.co//i/500x250?text=Normal%20image&bg=004500 1x, https://placeholdit.co//i/1000x500?text=Retina%20image&bg=004500 2x"
+            />
         </div>
     </div>
 );

--- a/examples/App.js
+++ b/examples/App.js
@@ -1,0 +1,66 @@
+import React from "react";
+import { FullsizePicture } from "../src";
+import cxs from "cxs/component";
+
+const StyledPicture = cxs(FullsizePicture)({
+    opacity: 0.8,
+});
+
+const Heading1 = cxs("h1")({
+    position: "relative",
+    textAlign: "center",
+    color: "white",
+});
+
+const App = () => (
+    <div>
+        <div style={{ height: 200 }}>
+            <StyledPicture
+                sources={[
+                    {
+                        srcSet:
+                            "https://edited.com/static/img/homepage/edited-hero-table-wide.jpg",
+                        media: "(max-width: 420px)",
+                    },
+                    {
+                        srcSet:
+                            "https://edited.com/static/img/homepage/edited-hero-table-wide.jpg",
+                    },
+                ]}
+                cover="height"
+                center={true}
+            />
+        </div>
+        <div style={{ height: 200 }}>
+            <FullsizePicture
+                sources={[
+                    {
+                        srcSet:
+                            "https://edited.com/static/img/homepage/edited-hero-table-wide.jpg",
+                        media: "(max-width: 420px)",
+                    },
+                    {
+                        srcSet:
+                            "https://edited.com/static/img/homepage/edited-hero-table-wide.jpg",
+                    },
+                ]}
+                cover="height"
+                center={true}
+            />
+        </div>
+        <div style={{ height: 200 }}>
+            <FullsizePicture
+                sources={[
+                    {
+                        srcSet:
+                            "https://images.unsplash.com/photo-1470619549108-b85c56fe5be8?dpr=2&auto=format&w=1024&h=1024",
+                    },
+                ]}
+            >
+                <Heading1 className="App-title">This is a heading</Heading1>
+            </FullsizePicture>
+        </div>
+    </div>
+);
+
+export default App;

--- a/examples/App.js
+++ b/examples/App.js
@@ -4,7 +4,8 @@ import cxs from "cxs/component";
 import { default as cxsStyles } from "cxs";
 
 const styles = cxsStyles({
-    opacity: 0.5,
+    border: "1px solid red",
+    boxShadow: "2px 2px 10px",
 });
 
 const Heading1 = cxs("h1")({
@@ -53,7 +54,7 @@ const App = () => (
         <h2>Full-width Picture with content</h2>
         <div style={{ height: 400 }}>
             <FullsizePicture
-                src="https://images.unsplash.com/photo-1470619549108-b85c56fe5be8?dpr=2&auto=format&w=1024&h=1024"
+                src="https://images.unsplash.com/photo-1520479627275-3eca80b17ecc?&auto=format&fit=crop&w=1280&q=80"
                 center={true}
             >
                 <Heading1 className="App-title">This is a heading</Heading1>
@@ -63,7 +64,7 @@ const App = () => (
         <div>
             <Picture
                 className={styles}
-                src="https://placeholdit.co//i/500x250?text=Normal%20image&bg=004500 1x, https://placeholdit.co//i/1000x500?text=Retina%20image&bg=004500 2x"
+                src="https://placeholdit.co//i/500x250?text=Normal%20image&bg=004500 1x, https://placeholdit.co//i/1000x500?text=Retina%20image&bg=007850 2x"
             />
         </div>
     </div>

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,1 @@
+<div id="root"></div>

--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+import React from "react";
+import { render } from "react-dom";
+import App from "./examples/App";
+
+render(<App />, document.getElementById("root"));

--- a/package.json
+++ b/package.json
@@ -1,75 +1,65 @@
 {
-  "name": "react-responsive-picture",
-  "version": "2.1.0",
-  "description": "A future-proof responsive image component that supports latest Picture specification",
-  "main": "./lib/index.js",
-  "module": "es/index.js",
-  "scripts": {
-    "build": "yarn run build:commonjs && yarn run build:es && npm run build:umd && npm run build:umd:min",
-    "build:es": "babel src -d es",
-    "build:commonjs": "cross-env BABEL_ENV=commonjs babel src -d lib",
-    "build:umd": "cross-env BABEL_ENV=commonjs NODE_ENV=development webpack src/index.js dist/react-responsive-picture.js",
-    "build:umd:min": "cross-env BABEL_ENV=commonjs NODE_ENV=production webpack src/index.js dist/react-responsive-picture.min.js",
-    "clean": "rimraf lib dist es",
-    "dev": "yarn run clean && cross-env BABEL_ENV=commonjs babel src -d lib --watch",
-    "lint": "eslint src/ --ext .js,.jsx",
-    "prepublish": "yarn run clean && yarn run build",
-    "release": "np",
-    "test": "echo \"No tests available\" && exit 0"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/EDITD/react-responsive-picture.git"
-  },
-  "files": [
-    "es",
-    "dist",
-    "lib",
-    "src"
-  ],
-  "keywords": [
-    "image",
-    "picture",
-    "responsive",
-    "react"
-  ],
-  "author": {
-    "name": "EDITED",
-    "email": "hello@edited.com",
-    "url": "http://edited.tech"
-  },
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/EDITD/react-responsive-picture/issues"
-  },
-  "homepage": "https://github.com/EDITD/react-responsive-picture#readme",
-  "devDependencies": {
-    "babel-cli": "^6.11.4",
-    "babel-core": "^6.25.0",
-    "babel-eslint": "^7.2.3",
-    "babel-loader": "^7.1.0",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.24.0",
-    "babel-plugin-transform-object-rest-spread": "^6.23.0",
-    "babel-preset-env": "^1.5.2",
-    "babel-preset-react": "^6.23.0",
-    "cross-env": "^5.0.1",
-    "eslint": "^4.0.0",
-    "eslint-config-edited": "^1.0.0",
-    "eslint-plugin-import": "^2.3.0",
-    "eslint-plugin-react": "^7.1.0",
-    "np": "^2.16.0",
-    "react": "^15.6.1",
-    "rimraf": "^2.4.3",
-    "webpack": "^3.0.0"
-  },
-  "peerDependencies": {
-    "react": "^15.0.1",
-    "react-dom": "^15.0.1"
-  },
-  "dependencies": {
-    "can-use-dom": "^0.1.0",
-    "cxs": "6.2.0",
-    "picturefill": "^3.0.2",
-    "prop-types": "^15.5.10"
-  }
+    "name": "react-responsive-picture",
+    "version": "2.1.0",
+    "description": "A future-proof responsive image component that supports latest Picture specification",
+    "main": "./lib/index.js",
+    "module": "es/index.js",
+    "scripts": {
+        "build": "yarn run build:commonjs && yarn run build:es && npm run build:umd && npm run build:umd:min",
+        "build:es": "babel src -d es",
+        "build:commonjs": "cross-env BABEL_ENV=commonjs babel src -d lib",
+        "build:umd": "cross-env BABEL_ENV=commonjs NODE_ENV=development webpack src/index.js dist/react-responsive-picture.js",
+        "build:umd:min": "cross-env BABEL_ENV=commonjs NODE_ENV=production webpack src/index.js dist/react-responsive-picture.min.js",
+        "clean": "rimraf lib dist es",
+        "dev": "yarn run clean && cross-env BABEL_ENV=commonjs babel src -d lib --watch",
+        "lint": "eslint src/ --ext .js,.jsx",
+        "prepublish": "yarn run clean && yarn run build",
+        "release": "np",
+        "test": "echo \"No tests available\" && exit 0"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/EDITD/react-responsive-picture.git"
+    },
+    "files": ["es", "dist", "lib", "src"],
+    "keywords": ["image", "picture", "responsive", "react"],
+    "author": {
+        "name": "EDITED",
+        "email": "hello@edited.com",
+        "url": "http://edited.tech"
+    },
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/EDITD/react-responsive-picture/issues"
+    },
+    "homepage": "https://github.com/EDITD/react-responsive-picture#readme",
+    "devDependencies": {
+        "babel-cli": "^6.11.4",
+        "babel-core": "^6.25.0",
+        "babel-eslint": "^7.2.3",
+        "babel-loader": "^7.1.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.0",
+        "babel-plugin-transform-object-rest-spread": "^6.23.0",
+        "babel-preset-env": "^1.5.2",
+        "babel-preset-react": "^6.23.0",
+        "cross-env": "^5.0.1",
+        "eslint": "^4.0.0",
+        "eslint-config-edited": "^1.0.0",
+        "eslint-plugin-import": "^2.3.0",
+        "eslint-plugin-react": "^7.1.0",
+        "np": "^2.16.0",
+        "react": "^15.6.1",
+        "rimraf": "^2.4.3",
+        "webpack": "^3.0.0"
+    },
+    "peerDependencies": {
+        "react": "^15.0.1",
+        "react-dom": "^15.0.1"
+    },
+    "dependencies": {
+        "can-use-dom": "0.1.0",
+        "cxs": "6.2.0",
+        "picturefill": "3.0.3",
+        "prop-types": "15.6.2"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "babel-core": "^6.25.0",
     "babel-eslint": "^7.2.3",
     "babel-loader": "^7.1.0",
-    "babel-plugin-glamorous-displayname": "^1.1.3",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.24.0",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-env": "^1.5.2",
@@ -58,20 +57,18 @@
     "eslint-config-edited": "^1.0.0",
     "eslint-plugin-import": "^2.3.0",
     "eslint-plugin-react": "^7.1.0",
-    "glamor": "^2.20.25",
     "np": "^2.16.0",
     "react": "^15.6.1",
     "rimraf": "^2.4.3",
     "webpack": "^3.0.0"
   },
   "peerDependencies": {
-    "glamor": "^2.20.25",
     "react": "^15.0.1",
     "react-dom": "^15.0.1"
   },
   "dependencies": {
     "can-use-dom": "^0.1.0",
-    "glamorous": "^3.23.3",
+    "cxs": "6.2.0",
     "picturefill": "^3.0.2",
     "prop-types": "^15.5.10"
   }

--- a/src/components/FullsizePicture.jsx
+++ b/src/components/FullsizePicture.jsx
@@ -1,86 +1,53 @@
 import Picture from "./Picture";
 import React from "react";
+import cxs from "cxs/component";
 import PropTypes from "prop-types";
-import glamorous from "glamorous";
 
-const Wrapper = glamorous.div(() => [
-    {
-        overflow: "hidden",
-        width: "100%",
-        height: "100%",
-        position: "relative",
-    },
-]);
+const Wrapper = cxs("div")({
+    width: "100%",
+    height: "100%",
+    position: "relative",
+});
 
-const PictureWrapper = glamorous.div(() => [
-    {
-        position: "absolute",
-        top: 0,
-        bottom: 0,
-        left: 0,
-        right: 0,
-    },
-]);
+const PictureWrapper = cxs("div")({
+    overflow: "hidden",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    position: "absolute",
+});
 
-class FullSizePicture extends React.PureComponent {
-    getImageStyles(propsStyle) {
-        return [
-            {
-                position: "absolute",
-                top: "50%",
-                left: "50%",
-                margin: "auto",
-                height: "auto",
-                minWidth: "100%",
-                minHeight: "100%",
-                maxWidth: "none",
-                maxHeight: "none",
-                transform: "translate3d(-50%, -50%, 0)",
-            },
-            propsStyle,
-        ];
-    }
+const Fullsized = Component => ({
+    className,
+    wrapperClassName,
+    children,
+    ...rest
+}) => {
+    const PictureComponent = cxs(Component)(
+        ({ cover = "width", center = false }) => ({
+            position: "absolute",
+            top: center ? "50%" : 0,
+            left: center ? "50%" : 0,
+            transform: center ? "translate(-50%, -50%)" : "none",
+            width: cover === "width" ? "100%" : "auto",
+            height: cover === "height" ? "100%" : "auto",
+        })
+    );
 
-    render() {
-        const {
-            className,
-            pictureClassName,
-            style,
-            pictureCSS,
-            css,
-            ...rest
-        } = this.props;
-        return (
-            <Wrapper className={className} css={css} style={style}>
-                <PictureWrapper>
-                    <Picture
-                        className={pictureClassName}
-                        css={this.getImageStyles(pictureCSS)}
-                        {...rest}
-                    />
-                </PictureWrapper>
-            </Wrapper>
-        );
-    }
-}
+    PictureComponent.propTypes = {
+        center: PropTypes.bool,
+        cover: PropTypes.string,
+    };
 
-FullSizePicture.propTypes = {
-    className: PropTypes.string,
-    pictureClassName: PropTypes.string,
-    alt: PropTypes.string,
-    sources: PropTypes.array,
-    src: PropTypes.string,
-    style: PropTypes.object,
-    css: PropTypes.oneOfType([
-        PropTypes.array,
-        PropTypes.object,
-        PropTypes.string,
-    ]),
-    pictureCSS: PropTypes.oneOfType([
-        PropTypes.array,
-        PropTypes.object,
-        PropTypes.string,
-    ]),
+    return (
+        <Wrapper className={wrapperClassName}>
+            <PictureWrapper>
+                <PictureComponent className={className} {...rest} />
+                {children}
+            </PictureWrapper>
+        </Wrapper>
+    );
 };
 
-export default FullSizePicture;
+export default Fullsized(Picture);

--- a/src/components/Picture.jsx
+++ b/src/components/Picture.jsx
@@ -1,24 +1,22 @@
-import React from "react";
+import * as React from "react";
 import PropTypes from "prop-types";
-import glamorous from "glamorous";
-import canUseDom from 'can-use-dom'
-
-const Img = glamorous.img();
+import canUseDom from "can-use-dom";
 
 class Picture extends React.PureComponent {
     componentDidMount() {
         // c.f. https://github.com/scottjehl/picturefill/pull/556
         var picturefill;
         try {
-            picturefill = require('picturefill');
-        } catch(x) {}
-        
+            picturefill = require("picturefill");
+        } catch (x) {}
+
         if (picturefill) picturefill(); // browser
         // else node
     }
 
     renderSources() {
-        const ieVersion = canUseDom && document.documentMode ? document.documentMode : -1;
+        const ieVersion =
+            canUseDom && document.documentMode ? document.documentMode : -1;
         const { sources } = this.props;
 
         if (sources == null) {
@@ -32,7 +30,7 @@ class Picture extends React.PureComponent {
 
             return (
                 <source
-                    key={index}
+                    key={`sources-${index}`}
                     srcSet={source.srcSet}
                     media={source.media}
                     type={source.type}
@@ -42,11 +40,7 @@ class Picture extends React.PureComponent {
 
         // IE9 requires the sources to be wrapped around an <audio> tag.
         if (ieVersion === 9) {
-            return (
-                <video style={{ display: "none" }}>
-                    {mappedSources}
-                </video>
-            );
+            return <video style={{ display: "none" }}>{mappedSources}</video>;
         }
 
         return mappedSources;
@@ -58,15 +52,7 @@ class Picture extends React.PureComponent {
         // Adds sizes props if sources isn't defined
         const sizesProp = skipSizes ? null : { sizes };
 
-        return (
-            <Img
-                alt={alt}
-                srcSet={src}
-                data-no-retina={true}
-                {...sizesProp}
-                {...rest}
-            />
-        );
+        return <img alt={alt} srcSet={src} {...sizesProp} {...rest} />;
     }
 
     render() {
@@ -87,19 +73,14 @@ class Picture extends React.PureComponent {
 Picture.propTypes = {
     sources: PropTypes.array,
     src: PropTypes.string.isRequired,
-    style: PropTypes.object,
-    css: PropTypes.oneOfType([
-        PropTypes.array,
-        PropTypes.object,
-        PropTypes.string,
-    ]),
     alt: PropTypes.string,
     className: PropTypes.string,
     sizes: PropTypes.string,
 };
 
 Picture.defaultProps = {
-    src: "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==",
+    src:
+        "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==",
 };
 
 export default Picture;


### PR DESCRIPTION
This improves the FullsizePicture component API and adds an examples page for Codesandbox.

**Breaking changes:**
- Removes `css` prop from `Picture` and `pictureCSS` prop from `FullsizePicture` component. Styling is now done exclusively through `className` prop.
- `className` prop in `FullsizePicture` is assigned to the inner `Picture` component to keep API consistency between components. It was previously called `pictureClassName`.
- New `wrapperClassName` prop to style wrapper component in `FullsizePicture`. It was previously called `className`
- `FullsizePicture` default behaviour now mimics `background-size: cover` behaviour for full-width images

Other changes: 
- Update to README and CONTRIBUTING docs
- Adds examples to be used in Codesandbox
- Removes `glamorous` and adds `cxs` for styling

This version also makes this library substantially smaller, bringing the size down from 26.4 kB to 7.72 kB (70% reduction).