### PR TITLE
Enhance Picture component

### DIFF
--- a/src/components/Picture.jsx
+++ b/src/components/Picture.jsx
@@ -8,7 +8,9 @@ class Picture extends React.PureComponent {
         let picturefill;
         try {
             picturefill = require("picturefill");
-        } catch (x) { return; }
+        } catch (x) {
+            return;
+        }
 
         if (picturefill) {
             picturefill(); // browser
@@ -73,9 +75,15 @@ class Picture extends React.PureComponent {
 }
 
 Picture.propTypes = {
-    sources: PropTypes.array,
+    sources: PropTypes.arrayOf(
+        PropTypes.shape({
+            srcSet: PropTypes.string.isRequired,
+            media: PropTypes.string,
+            type: PropTypes.string.isRequired,
+        })
+    ),
     src: PropTypes.string.isRequired,
-    alt: PropTypes.string,
+    alt: PropTypes.string.isRequired,
     className: PropTypes.string,
     sizes: PropTypes.string,
 };
@@ -83,6 +91,7 @@ Picture.propTypes = {
 Picture.defaultProps = {
     src:
         "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==",
+    alt: "",
 };
 
 export default Picture;

--- a/src/components/Picture.jsx
+++ b/src/components/Picture.jsx
@@ -56,7 +56,7 @@ class Picture extends React.PureComponent {
         // Adds sizes props if sources isn't defined
         const sizesProp = skipSizes ? null : { sizes };
 
-        return <img alt={alt} srcSet={src} {...sizesProp} {...rest} />;
+        return <img alt={alt || ""} srcSet={src} {...sizesProp} {...rest} />;
     }
 
     render() {
@@ -91,7 +91,6 @@ Picture.propTypes = {
 Picture.defaultProps = {
     src:
         "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==",
-    alt: "",
 };
 
 export default Picture;

--- a/src/components/Picture.jsx
+++ b/src/components/Picture.jsx
@@ -79,7 +79,7 @@ Picture.propTypes = {
         PropTypes.shape({
             srcSet: PropTypes.string.isRequired,
             media: PropTypes.string,
-            type: PropTypes.string.isRequired,
+            type: PropTypes.string,
         })
     ),
     src: PropTypes.string.isRequired,


### PR DESCRIPTION
This PR is for #24 

I've noticed that if no `alt` prop is provided then there is no default one for the `img` tag.

For accessibility purposes every image should have a default empty `alt` tag (also called the NULL `alt`text), implying they are just decorative images that serves no specific purpose.
You can read more about that on [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture#Usage_notes).

I also noticed that the `sources` prop in `propTypes` is just an `array`.
It should be at least a `PropTypes.arrayOf(PropTypes.object)`.
I think this is much more robust, anyway:
```javascript
sources: PropTypes.arrayOf(
     PropTypes.shape({
          srcSet: PropTypes.string.isRequired,
          media: PropTypes.string,
          type: PropTypes.string.isRequired,
     })
)
```

Fixes #24 